### PR TITLE
fix: trim padded reads to the declared frame length before decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to CRUMBS are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed host read paths passing the raw read size to the exact-length decoder
+  (#15). Linux i2c-dev reads return the requested byte count with `0xFF` bus
+  padding after the frame, so `crumbs_controller_read()`,
+  `crumbs_linux_read_message()`, and the CRUMBS scanners rejected every valid
+  reply (`-1`, trailing bytes) since the v0.12.4 strictness fix. All host read
+  helpers now trim to the header-declared frame length before decoding; the
+  `crumbs_decode_message()` exact-length contract itself is unchanged.
+
+### Added
+
+- Added `crumbs_frame_length()` for computing the header-declared frame length
+  of a padded read, for callers that hand raw reads to the decoder themselves.
+- Added padded-read regression coverage (`tests/test_padded_read.c`) using the
+  bench-captured reply from issue #15, exercising the trim helper,
+  `crumbs_controller_read()`, and the typed scanner against Linux-style padded
+  and all-`0xFF` reads.
+
 ## [0.12.4] - 2026-06-10
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,10 @@ if(CRUMBS_ENABLE_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/examples/families_usage/lhwit_family
     )
     add_test(NAME ops_validation_test COMMAND test_ops_validation)
+
+    add_executable(test_padded_read tests/test_padded_read.c)
+    target_link_libraries(test_padded_read PRIVATE crumbs)
+    add_test(NAME padded_read_test COMMAND test_padded_read)
 endif()
 
 # -----------------------------------------------------------------------------

--- a/src/core/crumbs_core.c
+++ b/src/core/crumbs_core.c
@@ -406,6 +406,38 @@ int crumbs_decode_message(const uint8_t *buffer,
 }
 
 /**
+ * @brief Length of the frame declared by a received header.
+ *
+ * Fixed-count transports (Linux i2c-dev) return the requested byte count
+ * with bus padding after the frame; the decoder's exact-length contract
+ * requires trimming to this length first.
+ */
+int crumbs_frame_length(const uint8_t *buffer,
+                        size_t buffer_len,
+                        size_t *frame_len)
+{
+    if (!buffer || !frame_len || buffer_len < k_min_frame_len)
+    {
+        return -1;
+    }
+
+    uint8_t data_len = buffer[2];
+    if (data_len > CRUMBS_MAX_PAYLOAD)
+    {
+        return -1; /* garbage header (e.g. all-0xFF read from a silent device) */
+    }
+
+    size_t declared = k_header_len + data_len + 1u;
+    if (buffer_len < declared)
+    {
+        return -1; /* genuinely truncated */
+    }
+
+    *frame_len = declared;
+    return 0;
+}
+
+/**
  * @brief Helper used by controllers to send a CRUMBS frame.
  */
 int crumbs_controller_send(const crumbs_context_t *ctx,
@@ -476,7 +508,17 @@ int crumbs_controller_read(crumbs_context_t *ctx,
 
     CRUMBS_DBG("rx: addr=0x%02X %d bytes\n", target_addr, n);
 
-    return crumbs_decode_message(buf, (size_t)n, out_msg, ctx);
+    /* Fixed-count transports pad the read past the frame; trim to the
+       header-declared length before the exact-length decode. */
+    size_t frame_len = 0u;
+    if (crumbs_frame_length(buf, (size_t)n, &frame_len) != 0)
+    {
+        CRUMBS_DBG("rx: invalid frame header\n");
+        ctx->last_crc_ok = 0u;
+        return -1;
+    }
+
+    return crumbs_decode_message(buf, frame_len, out_msg, ctx);
 }
 
 /**
@@ -685,10 +727,12 @@ int crumbs_controller_scan_for_crumbs_with_types(const crumbs_context_t *ctx,
         /* Attempt a direct read first (many peripherals reply on request).
            read_fn returns number of bytes read on success, negative on error. */
         int n = read_fn(io_ctx, (uint8_t)addr, buf, (size_t)CRUMBS_MESSAGE_MAX_SIZE, timeout_us);
-        if (n >= (int)k_min_frame_len)
+        size_t probe_frame_len = 0u;
+        if (n >= (int)k_min_frame_len &&
+            crumbs_frame_length(buf, (size_t)n, &probe_frame_len) == 0)
         {
             crumbs_message_t m;
-            if (crumbs_decode_message(buf, (size_t)n, &m, NULL) == 0)
+            if (crumbs_decode_message(buf, probe_frame_len, &m, NULL) == 0)
             {
                 if (count < max_found)
                 {
@@ -716,10 +760,12 @@ int crumbs_controller_scan_for_crumbs_with_types(const crumbs_context_t *ctx,
             (void)crumbs_controller_send(ctx, (uint8_t)addr, &probe, write_fn, io_ctx);
 
             int n2 = read_fn(io_ctx, (uint8_t)addr, buf, (size_t)CRUMBS_MESSAGE_MAX_SIZE, timeout_us);
-            if (n2 >= (int)k_min_frame_len)
+            size_t probe2_frame_len = 0u;
+            if (n2 >= (int)k_min_frame_len &&
+                crumbs_frame_length(buf, (size_t)n2, &probe2_frame_len) == 0)
             {
                 crumbs_message_t m2;
-                if (crumbs_decode_message(buf, (size_t)n2, &m2, NULL) == 0)
+                if (crumbs_decode_message(buf, probe2_frame_len, &m2, NULL) == 0)
                 {
                     if (count < max_found)
                     {

--- a/src/crumbs.h
+++ b/src/crumbs.h
@@ -371,6 +371,28 @@ extern "C"
                               crumbs_context_t *ctx);
 
     /**
+     * @brief Length of the frame declared by a received header.
+     *
+     * Transports that must request a fixed byte count up front (e.g. Linux
+     * i2c-dev) return the requested count with bus padding after the frame,
+     * because a peripheral writes only its actual frame and then stops
+     * driving the bus. crumbs_decode_message() enforces an exact frame
+     * length, so such reads must be trimmed to the header-declared length
+     * before decoding. All CRUMBS host read helpers do this internally;
+     * call it directly when handing raw reads to the decoder yourself.
+     *
+     * @param buffer     Bytes returned by the raw read.
+     * @param buffer_len Number of bytes the read returned.
+     * @param frame_len  Set to the declared frame length (4 + data_len) on success.
+     * @return 0 on success; -1 if the arguments are invalid, the read is
+     *         shorter than a minimum frame, the declared payload length is
+     *         out of range, or the read is shorter than the declared frame.
+     */
+    int crumbs_frame_length(const uint8_t *buffer,
+                            size_t buffer_len,
+                            size_t *frame_len);
+
+    /**
      * @brief Send a CRUMBS message to a 7-bit I2C target (controller helper).
      *
      * @param ctx Initialized CRUMBS context in controller mode.
@@ -390,7 +412,9 @@ extern "C"
      * @brief Read and decode a CRUMBS reply frame from a peripheral (controller helper).
      *
      * Symmetric counterpart to crumbs_controller_send(). Reads raw bytes via
-     * @p read_fn, then decodes them with crumbs_decode_message(). Passes
+     * @p read_fn, trims them to the header-declared frame length with
+     * crumbs_frame_length() (fixed-count transports pad reads past the frame),
+     * then decodes them with crumbs_decode_message(). Passes
      * timeout_us=0 to @p read_fn so the HAL uses its own default; call
      * delay_fn() before this to give the peripheral time to stage its reply
      * after a SET_REPLY write.

--- a/src/hal/linux/crumbs_i2c_linux.c
+++ b/src/hal/linux/crumbs_i2c_linux.c
@@ -156,8 +156,21 @@ int crumbs_linux_read_message(crumbs_linux_i2c_t *i2c,
         return -4;
     }
 
+    /* i2c-dev reads return the requested count with bus padding after the
+       frame; trim to the header-declared length before the exact-length
+       decode. */
+    size_t frame_len = 0u;
+    if (crumbs_frame_length(buf, total, &frame_len) != 0)
+    {
+        if (ctx)
+        {
+            ctx->last_crc_ok = 0u;
+        }
+        return -1; /* short read or garbage header */
+    }
+
     /* Decode with CRUMBS core -- validates CRC and updates ctx stats. */
-    int rc = crumbs_decode_message(buf, total, out_msg, ctx);
+    int rc = crumbs_decode_message(buf, frame_len, out_msg, ctx);
     return rc; /* 0 on success, <0 on decode/CRC error */
 }
 

--- a/tests/test_padded_read.c
+++ b/tests/test_padded_read.c
@@ -1,0 +1,269 @@
+/*
+ * Regression tests for reading CRUMBS frames over transports that return
+ * more bytes than the peripheral wrote (issue #15).
+ *
+ * A Linux I2C controller must request a fixed byte count up front. A CRUMBS
+ * peripheral writes only its actual frame and stops driving the bus, so the
+ * controller clocks in 0xFF for the remainder and the read returns the full
+ * requested count — the buffer size, not the frame size.
+ *
+ * crumbs_decode_message() enforces an exact-frame-length contract since
+ * v0.12.4 (trailing bytes -> -1), so host read paths must trim to the
+ * header-declared frame length before decoding. These tests pin that trim
+ * (crumbs_frame_length) and the read/scan entry points that use it, using
+ * fake read functions that pad like a real Linux bus read.
+ */
+
+#include "test_common.h"
+
+/*
+ * Captured from a live Slice_RLHT at 0x0A via `i2ctransfer -y 1 r31@0x0a`:
+ * a 9-byte version reply (type=0x01 opcode=0x00 data_len=5, CRC 0xE3)
+ * followed by 22 bytes of 0xFF bus padding.
+ */
+static const uint8_t k_bench_reply[CRUMBS_MESSAGE_MAX_SIZE] = {
+    0x01, 0x00, 0x05, 0xb4, 0x04, 0x01, 0x00, 0x00, 0xe3,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+#define BENCH_FRAME_LEN 9u
+
+/* ============================================================================
+ * crumbs_frame_length()
+ * ========================================================================= */
+
+static int test_frame_length_trims_padded_read(void)
+{
+    size_t frame_len = 0u;
+    int rc = crumbs_frame_length(k_bench_reply, sizeof(k_bench_reply), &frame_len);
+
+    TEST_ASSERT("frame_length_padded", rc == 0, "expected rc=0 for padded read");
+    TEST_ASSERT("frame_length_padded", frame_len == BENCH_FRAME_LEN,
+                "expected header-declared length (9), not the read length (31)");
+
+    printf("  frame_length trims padded read: PASS\n");
+    return 0;
+}
+
+static int test_frame_length_exact_frame_is_noop(void)
+{
+    size_t frame_len = 0u;
+    int rc = crumbs_frame_length(k_bench_reply, BENCH_FRAME_LEN, &frame_len);
+
+    TEST_ASSERT("frame_length_exact", rc == 0, "expected rc=0 for exact frame");
+    TEST_ASSERT("frame_length_exact", frame_len == BENCH_FRAME_LEN,
+                "exact-length input must pass through unchanged");
+
+    printf("  frame_length exact frame no-op: PASS\n");
+    return 0;
+}
+
+static int test_frame_length_zero_payload(void)
+{
+    /* data_len = 0 -> frame is header (3) + crc (1) = 4 bytes, then padding. */
+    const uint8_t frame[] = {0x01, 0x02, 0x00, 0x55, 0xff, 0xff, 0xff};
+    size_t frame_len = 0u;
+    int rc = crumbs_frame_length(frame, sizeof(frame), &frame_len);
+
+    TEST_ASSERT("frame_length_zero_payload", rc == 0, "expected rc=0");
+    TEST_ASSERT("frame_length_zero_payload", frame_len == 4u, "expected frame_len=4");
+
+    printf("  frame_length zero payload: PASS\n");
+    return 0;
+}
+
+static int test_frame_length_rejects_silent_device(void)
+{
+    /* All 0xFF: the device ACKed its address but supplied no data, so the
+       data_len byte (0xFF) is out of range. */
+    uint8_t garbage[CRUMBS_MESSAGE_MAX_SIZE];
+    memset(garbage, 0xff, sizeof(garbage));
+
+    size_t frame_len = 0u;
+    int rc = crumbs_frame_length(garbage, sizeof(garbage), &frame_len);
+
+    TEST_ASSERT("frame_length_garbage", rc != 0, "all-0xFF read must be rejected");
+
+    printf("  frame_length rejects silent device: PASS\n");
+    return 0;
+}
+
+static int test_frame_length_rejects_truncated(void)
+{
+    /* Header declares 5 payload bytes (frame = 9) but only 6 were read. */
+    size_t frame_len = 0u;
+    int rc = crumbs_frame_length(k_bench_reply, 6u, &frame_len);
+
+    TEST_ASSERT("frame_length_truncated", rc != 0, "truncated frame must be rejected");
+
+    printf("  frame_length rejects truncated frame: PASS\n");
+    return 0;
+}
+
+static int test_frame_length_rejects_bad_args(void)
+{
+    size_t frame_len = 0u;
+
+    TEST_ASSERT("frame_length_args", crumbs_frame_length(NULL, 31u, &frame_len) != 0,
+                "NULL buffer must be rejected");
+    TEST_ASSERT("frame_length_args", crumbs_frame_length(k_bench_reply, 31u, NULL) != 0,
+                "NULL out pointer must be rejected");
+    TEST_ASSERT("frame_length_args", crumbs_frame_length(k_bench_reply, 3u, &frame_len) != 0,
+                "read shorter than the minimum frame must be rejected");
+
+    printf("  frame_length rejects bad args: PASS\n");
+    return 0;
+}
+
+/* ============================================================================
+ * crumbs_decode_message() contract is unchanged
+ * ========================================================================= */
+
+static int test_decode_still_rejects_raw_padded_length(void)
+{
+    crumbs_context_t ctx;
+    crumbs_message_t msg;
+    crumbs_init(&ctx, CRUMBS_ROLE_CONTROLLER, 0u);
+
+    int rc = crumbs_decode_message(k_bench_reply, sizeof(k_bench_reply), &msg, &ctx);
+
+    TEST_ASSERT("decode_contract", rc == -1,
+                "decode must keep rejecting trailing bytes (v0.12.4 contract)");
+    TEST_ASSERT("decode_contract", ctx.last_crc_ok == 0u,
+                "rejected decode must clear last_crc_ok");
+
+    printf("  decode still rejects raw padded length: PASS\n");
+    return 0;
+}
+
+/* ============================================================================
+ * crumbs_controller_read() with a padding transport
+ * ========================================================================= */
+
+/* Fake read that behaves like Linux i2c-dev: fills the entire requested
+   buffer, frame first, 0xFF padding after, and returns the requested count. */
+static int fake_padded_read(void *user_ctx, uint8_t addr, uint8_t *buffer,
+                            size_t len, uint32_t timeout_us)
+{
+    (void)user_ctx;
+    (void)addr;
+    (void)timeout_us;
+
+    size_t n = len < sizeof(k_bench_reply) ? len : sizeof(k_bench_reply);
+    memcpy(buffer, k_bench_reply, n);
+    return (int)len;
+}
+
+static int fake_silent_read(void *user_ctx, uint8_t addr, uint8_t *buffer,
+                            size_t len, uint32_t timeout_us)
+{
+    (void)user_ctx;
+    (void)addr;
+    (void)timeout_us;
+
+    memset(buffer, 0xff, len);
+    return (int)len;
+}
+
+static int test_controller_read_decodes_padded_reply(void)
+{
+    crumbs_context_t ctx;
+    crumbs_message_t msg;
+    crumbs_init(&ctx, CRUMBS_ROLE_CONTROLLER, 0u);
+    memset(&msg, 0, sizeof(msg));
+
+    int rc = crumbs_controller_read(&ctx, 0x0A, &msg, fake_padded_read, NULL);
+
+    TEST_ASSERT("controller_read_padded", rc == 0,
+                "controller_read must decode a padded Linux-style read");
+    TEST_ASSERT("controller_read_padded", msg.type_id == 0x01, "wrong type_id");
+    TEST_ASSERT("controller_read_padded", msg.opcode == 0x00, "wrong opcode");
+    TEST_ASSERT("controller_read_padded", msg.data_len == 5u, "wrong data_len");
+    TEST_ASSERT("controller_read_padded", msg.crc8 == 0xE3, "wrong crc8");
+    TEST_ASSERT("controller_read_padded", ctx.last_crc_ok == 1u,
+                "successful decode must set last_crc_ok");
+
+    printf("  controller_read decodes padded reply: PASS\n");
+    return 0;
+}
+
+static int test_controller_read_rejects_silent_device(void)
+{
+    crumbs_context_t ctx;
+    crumbs_message_t msg;
+    crumbs_init(&ctx, CRUMBS_ROLE_CONTROLLER, 0u);
+
+    int rc = crumbs_controller_read(&ctx, 0x0A, &msg, fake_silent_read, NULL);
+
+    TEST_ASSERT("controller_read_silent", rc != 0,
+                "an all-0xFF read must not decode");
+    TEST_ASSERT("controller_read_silent", ctx.last_crc_ok == 0u,
+                "failed read must clear last_crc_ok");
+
+    printf("  controller_read rejects silent device: PASS\n");
+    return 0;
+}
+
+/* ============================================================================
+ * Scanner with a padding transport
+ * ========================================================================= */
+
+#define PADDED_DEV 0x0A
+
+static int fake_padded_scan_read(void *user_ctx, uint8_t addr, uint8_t *buffer,
+                                 size_t len, uint32_t timeout_us)
+{
+    (void)user_ctx;
+    (void)timeout_us;
+
+    if (addr != PADDED_DEV)
+        return -1; /* no device: address NAK */
+
+    return fake_padded_read(NULL, addr, buffer, len, 0u);
+}
+
+static int test_scan_finds_device_behind_padded_reads(void)
+{
+    uint8_t found[4];
+    uint8_t types[4];
+
+    int n = crumbs_controller_scan_for_crumbs_with_types(
+        NULL, 0x08, 0x10, 1 /* strict */, NULL, fake_padded_scan_read, NULL,
+        found, types, 4u, 0u);
+
+    TEST_ASSERT("scan_padded", n == 1, "expected exactly one device found");
+    TEST_ASSERT("scan_padded", found[0] == PADDED_DEV, "wrong address found");
+    TEST_ASSERT("scan_padded", types[0] == 0x01, "wrong type_id reported");
+
+    printf("  scan finds device behind padded reads: PASS\n");
+    return 0;
+}
+
+int main(void)
+{
+    int failures = 0;
+
+    printf("Running padded-read tests:\n");
+
+    failures += test_frame_length_trims_padded_read();
+    failures += test_frame_length_exact_frame_is_noop();
+    failures += test_frame_length_zero_payload();
+    failures += test_frame_length_rejects_silent_device();
+    failures += test_frame_length_rejects_truncated();
+    failures += test_frame_length_rejects_bad_args();
+    failures += test_decode_still_rejects_raw_padded_length();
+    failures += test_controller_read_decodes_padded_reply();
+    failures += test_controller_read_rejects_silent_device();
+    failures += test_scan_finds_device_behind_padded_reads();
+
+    if (failures == 0)
+    {
+        printf("OK all padded-read tests passed\n");
+        return 0;
+    }
+    else
+    {
+        fprintf(stderr, "FAILED %d test(s)\n", failures);
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #15. Since v0.12.4 made `crumbs_decode_message()` enforce its exact-frame-length contract, every host read path that handed the raw read size to the decoder rejected every valid reply with `-1` (trailing bytes). Linux i2c-dev reads return the requested byte count with `0xFF` bus padding after the frame — the read length is the buffer size, not the frame size.

Broken sites, all fixed here:
- `crumbs_controller_read()` (core)
- both scanner probe decodes in `crumbs_controller_scan_for_crumbs_with_types()` — the Linux typed scan found nothing under 0.12.4
- `crumbs_linux_read_message()` (Linux HAL)

## Change

New public helper `crumbs_frame_length()` computes the header-declared frame length (`4 + data_len`) and validates the read against it (rejects short reads, out-of-range `data_len` such as all-`0xFF` reads from a silent device, and genuinely truncated frames). All four host read sites trim to that length before decoding.

**The decoder's exact-length contract is unchanged** — a regression test asserts the raw padded length is still rejected. CRC is still verified over the correct span. Arduino-to-Arduino paths are unaffected (exact-length reads trim to themselves).

## Verification

- `ctest`: 14/14 suites pass, both core-only and `CRUMBS_ENABLE_LINUX_HAL=ON` builds, zero warnings.
- New `tests/test_padded_read.c` uses the bench-captured Slice_RLHT reply from the issue (9-byte frame + 22 bytes padding) against the trim helper, `crumbs_controller_read()`, and the typed scanner — the padding-transport fakes that were missing from the original scan tests.
- **Hardware**: compiled this branch on the bench Pi against three live slice boards. Typed scan over 0x08-0x20: found all 3 devices with correct type IDs (RLHT 0x01, DCMT 0x02x2). `SET_REPLY` -> `crumbs_linux_read_message()`: **150/150 decoded** (was 0% under 0.12.4).

Downstream: anolis-provider-bread can drop its caller-side trim workaround (anolishq/anolis-provider-bread#96) once this releases as 0.12.5.
