### PR TITLE
chore: release v0.12.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to CRUMBS are documented in this file.
 
 ## [Unreleased]
 
+## [0.12.5] - 2026-07-13
+
 ### Fixed
 
 - Fixed host read paths passing the raw read size to the exact-length decoder

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 project(CRUMBS
-    VERSION 0.12.4
+    VERSION 0.12.5
     LANGUAGES C
 )
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ CRUMBS is designed to work seamlessly with Arduino IDE and PlatformIO:
 ```ini
 # platformio.ini
 lib_deps =
-    cameronbrooks11/CRUMBS@^0.12.4
+    cameronbrooks11/CRUMBS@^0.12.5
 ```
 
 Or for local development (see [Local Development](#local-development-with-platformio) below).
@@ -229,7 +229,7 @@ When developing changes to CRUMBS itself, test locally before publishing:
    ```ini
    # Change from registry version
    lib_deps =
-       cameronbrooks11/CRUMBS@^0.12.4
+       cameronbrooks11/CRUMBS@^0.12.5
 
    # To local symlink
    lib_deps =
@@ -249,7 +249,7 @@ When developing changes to CRUMBS itself, test locally before publishing:
 
    ```ini
    lib_deps =
-       cameronbrooks11/CRUMBS@^0.12.4
+       cameronbrooks11/CRUMBS@^0.12.5
    ```
 
 **Path explanation:**

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Upload [hello examples](examples/core_usage/arduino/hello_peripheral/) to two Ar
 
 ```ini
 [env]
-lib_deps = cameronbrooks11/CRUMBS@^0.12.4
+lib_deps = cameronbrooks11/CRUMBS@^0.12.5
 ```
 
 **Arduino IDE:** Tools → Manage Libraries → "CRUMBS" → Install, or copy to `~/Arduino/libraries/`

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -63,7 +63,7 @@ typedef struct crumbs_context_t {
 #define CRUMBS_MAX_PAYLOAD      27    // Maximum payload bytes
 #define CRUMBS_MESSAGE_MAX_SIZE 31    // Maximum serialized frame size
 #define CRUMBS_CMD_SET_REPLY    0xFE  // Reserved opcode for SET_REPLY command
-#define CRUMBS_VERSION          1204  // Library version (1204 = v0.12.4, formula: major*10000 + minor*100 + patch)
+#define CRUMBS_VERSION          1204  // Library version (1204 = v0.12.5, formula: major*10000 + minor*100 + patch)
 ```
 
 ### Bound-Device Handle

--- a/docs/index.md
+++ b/docs/index.md
@@ -225,7 +225,7 @@ Historical and technical deep-dive documents are in [archive/](archive/):
 
 ---
 
-**Version**: 0.12.4
+**Version**: 0.12.5
 **Author**: Cameron K. Brooks  
 **Dependencies**: Wire library (Arduino), linux-wire (Linux HAL)  
 **License**: AGPL-3.0-or-later

--- a/docs/platform-setup.md
+++ b/docs/platform-setup.md
@@ -160,7 +160,7 @@ board = nanoatmega328new
 framework = arduino
 
 lib_deps =
-    cameronbrooks11/CRUMBS@^0.12.4
+    cameronbrooks11/CRUMBS@^0.12.5
 
 build_flags =
     -DCRUMBS_MAX_HANDLERS=8  ; optional: reduce handler table size
@@ -175,7 +175,7 @@ board = esp32dev
 framework = arduino
 
 lib_deps =
-    cameronbrooks11/CRUMBS@^0.12.4
+    cameronbrooks11/CRUMBS@^0.12.5
 
 build_flags =
     -DCRUMBS_MAX_HANDLERS=8  ; optional

--- a/examples/core_usage/platformio/simple_controller/platformio.ini
+++ b/examples/core_usage/platformio/simple_controller/platformio.ini
@@ -15,7 +15,7 @@ framework = arduino
 upload_speed = 115200
 monitor_speed = 115200
 lib_deps = 
-	cameronbrooks11/CRUMBS@^0.12.4
+	cameronbrooks11/CRUMBS@^0.12.5
 
 [env:nanoatmega328old]
 platform = atmelavr
@@ -24,7 +24,7 @@ framework = arduino
 upload_speed = 57600
 monitor_speed = 115200
 lib_deps =
-    cameronbrooks11/CRUMBS@^0.12.4
+    cameronbrooks11/CRUMBS@^0.12.5
 
 [env:esp32dev]
 platform = espressif32
@@ -32,7 +32,7 @@ board = esp32dev
 framework = arduino
 monitor_speed = 115200
 lib_deps =
-	cameronbrooks11/CRUMBS@^0.12.4
+	cameronbrooks11/CRUMBS@^0.12.5
 
 [platformio]
 default_envs = nanoatmega328new

--- a/examples/core_usage/platformio/simple_peripheral/platformio.ini
+++ b/examples/core_usage/platformio/simple_peripheral/platformio.ini
@@ -15,7 +15,7 @@ framework = arduino
 upload_speed = 115200
 monitor_speed = 115200
 lib_deps = 
-	cameronbrooks11/CRUMBS@^0.12.4
+	cameronbrooks11/CRUMBS@^0.12.5
 
 [env:nanoatmega328old]
 platform = atmelavr
@@ -24,7 +24,7 @@ framework = arduino
 upload_speed = 57600
 monitor_speed = 115200
 lib_deps =
-    cameronbrooks11/CRUMBS@^0.12.4
+    cameronbrooks11/CRUMBS@^0.12.5
 
 [env:esp32dev]
 platform = espressif32
@@ -32,7 +32,7 @@ board = esp32dev
 framework = arduino
 monitor_speed = 115200
 lib_deps =
-	cameronbrooks11/CRUMBS@^0.12.4
+	cameronbrooks11/CRUMBS@^0.12.5
 
 [platformio]
 default_envs = nanoatmega328new

--- a/examples/families_usage/controller_discovery/README.md
+++ b/examples/families_usage/controller_discovery/README.md
@@ -72,9 +72,9 @@ make
 ```sh
 lhwit> scan
 Scanning for CRUMBS devices...
-Found Calculator at 0x10 (CRUMBS 0.12.4, Module 1.0.0) - Compatible
-Found LED Array at 0x20 (CRUMBS 0.12.4, Module 1.0.0) - Compatible
-Found Servo Controller at 0x30 (CRUMBS 0.12.4, Module 1.0.0) - Compatible
+Found Calculator at 0x10 (CRUMBS 0.12.5, Module 1.0.0) - Compatible
+Found LED Array at 0x20 (CRUMBS 0.12.5, Module 1.0.0) - Compatible
+Found Servo Controller at 0x30 (CRUMBS 0.12.5, Module 1.0.0) - Compatible
 
 Found 3 CRUMBS device(s):
   [0] Address 0x10, Type 0x03 (Calculator)

--- a/examples/families_usage/lhwit_family/calculator/platformio.ini
+++ b/examples/families_usage/lhwit_family/calculator/platformio.ini
@@ -8,7 +8,7 @@ build_flags =
 	-DCRUMBS_MAX_HANDLERS=8
 	-I ..
 lib_deps = 
-	cameronbrooks11/CRUMBS@^0.12.4
+	cameronbrooks11/CRUMBS@^0.12.5
 
 [env:nanoatmega328old]
 platform = atmelavr
@@ -20,7 +20,7 @@ build_flags =
     -DCRUMBS_MAX_HANDLERS=8
     -I ..
 lib_deps =
-    cameronbrooks11/CRUMBS@^0.12.4
+    cameronbrooks11/CRUMBS@^0.12.5
 
 [env:esp32dev]
 platform = espressif32
@@ -31,7 +31,7 @@ build_flags =
 	-DCRUMBS_MAX_HANDLERS=8
 	-I ..
 lib_deps =
-	cameronbrooks11/CRUMBS@^0.12.4
+	cameronbrooks11/CRUMBS@^0.12.5
 
 [platformio]
 default_envs = nanoatmega328new

--- a/examples/families_usage/lhwit_family/display/platformio.ini
+++ b/examples/families_usage/lhwit_family/display/platformio.ini
@@ -8,7 +8,7 @@ build_flags =
 	-DCRUMBS_MAX_HANDLERS=6
 	-I ..
 lib_deps = 
-	cameronbrooks11/CRUMBS@^0.12.4
+	cameronbrooks11/CRUMBS@^0.12.5
 	adrian200223/Simple5641AS@^1.0.0
 
 [env:nanoatmega328old]
@@ -21,7 +21,7 @@ build_flags =
     -DCRUMBS_MAX_HANDLERS=6
     -I ..
 lib_deps =
-    cameronbrooks11/CRUMBS@^0.12.4
+    cameronbrooks11/CRUMBS@^0.12.5
     adrian200223/Simple5641AS@^1.0.0
 
 [env:esp32dev]
@@ -33,7 +33,7 @@ build_flags =
 	-DCRUMBS_MAX_HANDLERS=6
 	-I ..
 lib_deps =
-	cameronbrooks11/CRUMBS@^0.12.4
+	cameronbrooks11/CRUMBS@^0.12.5
 	adrian200223/Simple5641AS@^1.0.0
 
 [platformio]

--- a/examples/families_usage/lhwit_family/led/platformio.ini
+++ b/examples/families_usage/lhwit_family/led/platformio.ini
@@ -8,7 +8,7 @@ build_flags =
 	-DCRUMBS_MAX_HANDLERS=8
 	-I ..
 lib_deps = 
-	cameronbrooks11/CRUMBS@^0.12.4
+	cameronbrooks11/CRUMBS@^0.12.5
 
 [env:nanoatmega328old]
 platform = atmelavr
@@ -20,7 +20,7 @@ build_flags =
     -DCRUMBS_MAX_HANDLERS=8
     -I ..
 lib_deps =
-    cameronbrooks11/CRUMBS@^0.12.4
+    cameronbrooks11/CRUMBS@^0.12.5
 
 [env:esp32dev]
 platform = espressif32
@@ -31,7 +31,7 @@ build_flags =
 	-DCRUMBS_MAX_HANDLERS=8
 	-I ..
 lib_deps =
-	cameronbrooks11/CRUMBS@^0.12.4
+	cameronbrooks11/CRUMBS@^0.12.5
 
 [platformio]
 default_envs = nanoatmega328new

--- a/examples/families_usage/lhwit_family/servo/platformio.ini
+++ b/examples/families_usage/lhwit_family/servo/platformio.ini
@@ -8,7 +8,7 @@ build_flags =
 	-DCRUMBS_MAX_HANDLERS=8
 	-I ..
 lib_deps = 
-	cameronbrooks11/CRUMBS@^0.12.4
+	cameronbrooks11/CRUMBS@^0.12.5
 	Servo
 
 [env:nanoatmega328old]
@@ -21,7 +21,7 @@ build_flags =
     -DCRUMBS_MAX_HANDLERS=8
     -I ..
 lib_deps =
-    cameronbrooks11/CRUMBS@^0.12.4
+    cameronbrooks11/CRUMBS@^0.12.5
     Servo
 
 [env:esp32dev]
@@ -33,7 +33,7 @@ build_flags =
 	-DCRUMBS_MAX_HANDLERS=8
 	-I ..
 lib_deps =
-	cameronbrooks11/CRUMBS@^0.12.4
+	cameronbrooks11/CRUMBS@^0.12.5
 	Servo
 
 [platformio]

--- a/examples/handlers_usage/platformio/mock_controller/platformio.ini
+++ b/examples/handlers_usage/platformio/mock_controller/platformio.ini
@@ -7,7 +7,7 @@ monitor_speed = 115200
 build_flags = 
 	-I ../..
 lib_deps = 
-	cameronbrooks11/CRUMBS@^0.12.4
+	cameronbrooks11/CRUMBS@^0.12.5
 
 [env:nanoatmega328old]
 platform = atmelavr
@@ -18,7 +18,7 @@ monitor_speed = 115200
 build_flags =
     -I ../..
 lib_deps =
-    cameronbrooks11/CRUMBS@^0.12.4
+    cameronbrooks11/CRUMBS@^0.12.5
 
 [env:esp32dev]
 platform = espressif32
@@ -28,7 +28,7 @@ monitor_speed = 115200
 build_flags =
 	-I ../..
 lib_deps =
-	cameronbrooks11/CRUMBS@^0.12.4
+	cameronbrooks11/CRUMBS@^0.12.5
 
 [platformio]
 default_envs = nanoatmega328new

--- a/examples/handlers_usage/platformio/mock_peripheral/platformio.ini
+++ b/examples/handlers_usage/platformio/mock_peripheral/platformio.ini
@@ -8,7 +8,7 @@ build_flags =
 	-DCRUMBS_MAX_HANDLERS=8
 	-I ../..
 lib_deps = 
-	cameronbrooks11/CRUMBS@^0.12.4
+	cameronbrooks11/CRUMBS@^0.12.5
 
 [env:nanoatmega328old]
 platform = atmelavr
@@ -20,7 +20,7 @@ build_flags =
     -DCRUMBS_MAX_HANDLERS=8
     -I ../..
 lib_deps =
-    cameronbrooks11/CRUMBS@^0.12.4
+    cameronbrooks11/CRUMBS@^0.12.5
 
 [env:esp32dev]
 platform = espressif32
@@ -31,7 +31,7 @@ build_flags =
 	-DCRUMBS_MAX_HANDLERS=8
 	-I ../..
 lib_deps =
-	cameronbrooks11/CRUMBS@^0.12.4
+	cameronbrooks11/CRUMBS@^0.12.5
 
 [platformio]
 default_envs = nanoatmega328new

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "CRUMBS",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "CRUMBS: a small, portable C-based protocol for controller/peripheral I2C messaging (Arduino + Linux HALs).",
   "keywords": "i2c,crumbs,crc,arduino,linux,protocol",
   "repository": {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=CRUMBS
-version=0.12.4
+version=0.12.5
 author=Cameron
 maintainer=Cameron <cambrooks3393@gmail.com>
 sentence=CRUMBS: A communication library for managing data exchange between peripheral devices and a controller using serialization over I2C.

--- a/src/crumbs_version.h
+++ b/src/crumbs_version.h
@@ -3,8 +3,8 @@
 
 #define CRUMBS_VERSION_MAJOR 0
 #define CRUMBS_VERSION_MINOR 12
-#define CRUMBS_VERSION_PATCH 4
-#define CRUMBS_VERSION_STRING "0.12.4"
-#define CRUMBS_VERSION 1204 // major*10000 + minor*100 + patch
+#define CRUMBS_VERSION_PATCH 5
+#define CRUMBS_VERSION_STRING "0.12.5"
+#define CRUMBS_VERSION 1205 // major*10000 + minor*100 + patch
 
 #endif // CRUMBS_VERSION_H


### PR DESCRIPTION
Version bump for the v0.12.5 release (already tagged and published — the tag points at this commit; merging with a merge commit lands the exact tagged SHA on main, matching every prior release).

Release: https://github.com/feastorg/CRUMBS/releases/tag/v0.12.5
Contents: the #15 fix (padded-read trimming) — see CHANGELOG.